### PR TITLE
Add functions to evaluate classification performance

### DIFF
--- a/lib/trainer.py
+++ b/lib/trainer.py
@@ -12,7 +12,7 @@ from collections import OrderedDict
 from copy import deepcopy
 from tensorboardX import SummaryWriter
 
-from sklearn.metrics import roc_auc_score, log_loss, accuracy_score, precision_score, recall_score
+from sklearn.metrics import roc_auc_score, log_loss, accuracy_score, precision_score, recall_score, f1_score
 
 
 class Trainer(nn.Module):
@@ -202,3 +202,14 @@ class Trainer(nn.Module):
             prediction = np.argmax(prediction, axis=1)
             recall = recall_score(y_test, prediction, average=average)
         return recall
+
+    def evaluate_f1_score(self, X_test, y_test, device, batch_size=512, average="micro"):
+        X_test = torch.as_tensor(X_test, device=device)
+        y_test = check_numpy(y_test)
+        self.model.train(False)
+        with torch.no_grad():
+            prediction = process_in_chunks(self.model, X_test, batch_size=batch_size)
+            prediction = check_numpy(prediction)
+            prediction = np.argmax(prediction, axis=1)
+            f1score = f1_score(y_test, prediction, average=average)
+        return f1score

--- a/lib/trainer.py
+++ b/lib/trainer.py
@@ -12,7 +12,7 @@ from collections import OrderedDict
 from copy import deepcopy
 from tensorboardX import SummaryWriter
 
-from sklearn.metrics import roc_auc_score, log_loss, accuracy_score
+from sklearn.metrics import roc_auc_score, log_loss, accuracy_score, precision_score
 
 
 class Trainer(nn.Module):
@@ -180,3 +180,14 @@ class Trainer(nn.Module):
             prediction = np.argmax(prediction, axis=1)
             accuracy = accuracy_score(y_test, prediction)
         return accuracy
+
+    def evaluate_precision(self, X_test, y_test, device, batch_size=512, average="micro"):
+        X_test = torch.as_tensor(X_test, device=device)
+        y_test = check_numpy(y_test)
+        self.model.train(False)
+        with torch.no_grad():
+            prediction = process_in_chunks(self.model, X_test, batch_size=batch_size)
+            prediction = check_numpy(prediction)
+            prediction = np.argmax(prediction, axis=1)
+            precision = precision_score(y_test, prediction, average=average)
+        return precision

--- a/lib/trainer.py
+++ b/lib/trainer.py
@@ -12,7 +12,7 @@ from collections import OrderedDict
 from copy import deepcopy
 from tensorboardX import SummaryWriter
 
-from sklearn.metrics import roc_auc_score, log_loss
+from sklearn.metrics import roc_auc_score, log_loss, accuracy_score
 
 
 class Trainer(nn.Module):
@@ -169,3 +169,14 @@ class Trainer(nn.Module):
             y_test = torch.tensor(y_test)
             logloss = log_loss(check_numpy(to_one_hot(y_test)), logits)
         return logloss
+
+    def evaluate_accuracy(self, X_test, y_test, device, batch_size=512):
+        X_test = torch.as_tensor(X_test, device=device)
+        y_test = check_numpy(y_test)
+        self.model.train(False)
+        with torch.no_grad():
+            prediction = process_in_chunks(self.model, X_test, batch_size=batch_size)
+            prediction = check_numpy(prediction)
+            prediction = np.argmax(prediction, axis=1)
+            accuracy = accuracy_score(y_test, prediction)
+        return accuracy

--- a/lib/trainer.py
+++ b/lib/trainer.py
@@ -12,7 +12,7 @@ from collections import OrderedDict
 from copy import deepcopy
 from tensorboardX import SummaryWriter
 
-from sklearn.metrics import roc_auc_score, log_loss, accuracy_score, precision_score
+from sklearn.metrics import roc_auc_score, log_loss, accuracy_score, precision_score, recall_score
 
 
 class Trainer(nn.Module):
@@ -191,3 +191,14 @@ class Trainer(nn.Module):
             prediction = np.argmax(prediction, axis=1)
             precision = precision_score(y_test, prediction, average=average)
         return precision
+
+    def evaluate_recall(self, X_test, y_test, device, batch_size=512, average="micro"):
+        X_test = torch.as_tensor(X_test, device=device)
+        y_test = check_numpy(y_test)
+        self.model.train(False)
+        with torch.no_grad():
+            prediction = process_in_chunks(self.model, X_test, batch_size=batch_size)
+            prediction = check_numpy(prediction)
+            prediction = np.argmax(prediction, axis=1)
+            recall = recall_score(y_test, prediction, average=average)
+        return recall


### PR DESCRIPTION
Hello,

I'm using node in a ongoing research project and needed to extract some common classification metrics (accuracy, recall, precision and F1 score).

In the notebooks I saw examples of how to extract MSE and classification error. Looking at the [`trainer.py`](https://github.com/Qwicen/node/blob/master/lib/trainer.py) code I noticed there was already a implementation for getting also AUC and logloss. So I took the liberty of, following the coding pattern, implement functions to extract the metrics I needed.

The usage follows the pattern of the `evaluate_classification_error`, `evaluate_mse`, `evaluate_auc` and `evaluate_logloss` functions:

```python
trainer.load_checkpoint(tag='best')

accuracy = trainer.evaluate_accuracy(data.X_test, data.y_test, device=device)
precision = trainer.evaluate_precision(data.X_test, data.y_test, device=device)
recall = trainer.evaluate_recall(data.X_test, data.y_test, device=device)
f1_score = trainer.evaluate_f1_score(data.X_test, data.y_test, device=device)
```

For `evaluate_precision`, `evaluate_recall`  and `evaluate_f1_score` functions you can also specify an average (for multiclass/multilabel classification use cases).
